### PR TITLE
Fix plus bigint

### DIFF
--- a/src/ContractMsgport.ts
+++ b/src/ContractMsgport.ts
@@ -67,7 +67,7 @@ ORMPUpgradeablePortContract.MessageRecv.handler(({event, context}) => {
     const nextMessageProgress = {
       id: mpId,
       total: currentMessageProgress.total,
-      inflight: currentMessageProgress.inflight + 1,
+      inflight: currentMessageProgress.inflight + 1n,
     };
     context.MessageProgress.set(nextMessageProgress);
   }
@@ -138,8 +138,8 @@ ORMPUpgradeablePortContract.MessageSent.handler(({event, context}) => {
   const currentMessageProgress: MessageProgressEntity = messageProgress ?? INITIAL_MESSAGE_PROGRESS;
   const nextMessageProgress = {
     id: mpId,
-    total: currentMessageProgress.total + 1,
-    inflight: currentMessageProgress.inflight + 1,
+    total: currentMessageProgress.total + 1n,
+    inflight: currentMessageProgress.inflight + 1n,
   };
   context.MessageProgress.set(nextMessageProgress);
 


### PR DESCRIPTION
	⨯ Unable to compile TypeScript: src/ContractMsgport.ts(70,17): error TS2365: Operator '+' cannot be applied to types 'bigint' and '1'. src/ContractMsgport.ts(141,12): error TS2365: Operator '+' cannot be applied to types 'bigint' and '1'. src/ContractMsgport.ts(142,15): error TS2365: Operator '+' cannot be applied to types 'bigint' and '1'. 	